### PR TITLE
Bugfixes from WTA

### DIFF
--- a/Products/salesforcepfgadapter/content/salesforcepfgadapter.py
+++ b/Products/salesforcepfgadapter/content/salesforcepfgadapter.py
@@ -430,7 +430,7 @@ due to an exception: %s
             mailer.send_form(fields, REQUEST)
 
     def _userIdToUpdate(self, sObject):
-        if len(sObject.keys()) == 1:
+        if 'Id' not in sObject.keys():
             # only 'type' --> means no mapped fields, so do lookup now
             data = self.retrieveData()
             if not data:

--- a/Products/salesforcepfgadapter/content/salesforcepfgadapter.py
+++ b/Products/salesforcepfgadapter/content/salesforcepfgadapter.py
@@ -34,6 +34,7 @@ except ImportError:
 from Products.CMFCore.Expression import Expression
 
 # Plone imports
+from Products.CMFPlone.interfaces import IMailSchema
 from Products.CMFPlone.utils import safe_hasattr
 from Products.CMFPlone.PloneBaseTool import getExprContext
 from Products.Archetypes.public import StringField, StringWidget, \
@@ -413,13 +414,16 @@ due to an exception: %s
             err_msg = 'Technical details on the exception: '
             err_msg += ''.join(traceback.format_exception_only(t, v))
 
+
+            registry = getToolByName(self, 'portal_registry')
+            site_from_address = registry.forInterface(IMailSchema, prefix='plone').email_from_address
             mailer = FormMailerAdapter('dummy').__of__(formFolder)
             mailer.msg_subject = 'Form submission to Salesforce failed'
             mailer.subject_field = None
             # we rely on the PFG mailer's logic to choose a good fallback recipient
             mailer.recipient_name = ''
             mailer.recipient_email = ''
-            mailer.cc_recipients = []
+            mailer.cc_recipients = [site_from_address, ]
             mailer.bcc_recipients = []
             mailer.additional_headers = []
             mailer.body_type = 'html'


### PR DESCRIPTION
Hi anyone and everyone that's looking,

WTA have had some intermittent issues with this adapter failing when the REQUEST.SESSION doesn't contain the cached information for the sObject. This PR fixes the logic for determining if `retrieveData` should be called and adds the site from address as a CC to error warning emails (which currently only go to the Owner of the form).

Is anyone currently maintaining this package, or does anyone have strong feelings about these changes?